### PR TITLE
Sticky aside on viewports above 640px

### DIFF
--- a/src/routes/docs/[slug].svelte
+++ b/src/routes/docs/[slug].svelte
@@ -27,6 +27,10 @@
   aside {
     width: 240px;
     flex-shrink: 0;
+    position:sticky;
+    top:0;
+    max-height:100vh;
+    overflow-y:scroll;
   }
   aside ul {
     margin: 0;
@@ -77,6 +81,10 @@
     aside {
       margin-bottom: 6rem;
       width: 100%;
+      position:unset;
+      top:0;
+      max-height:unset;
+      overflow-y:unset;
     }
   }
 </style>


### PR DESCRIPTION
Work that was previously bundled with the SVG PR. This sets an aside to be sticky and have a maximum height that matches the viewport. It should not affect the aside on a small viewport where it's meant to be stacked. We started seeing issues (a lack of browser testing on my part really) so here's a dedicated PR where issues will be addressed separately.