### PR TITLE
Add arp latch CC# to midi.md

### DIFF
--- a/src/routes/docs/posts/midi.md
+++ b/src/routes/docs/posts/midi.md
@@ -39,6 +39,7 @@ CC| Category | Parameter
 92 | FX - Reverb | Reverb time
 93 | FX - Reverb | Reverb shimmer
 114 | FX - Reverb | Reverb wobble
+101 | ARP | Latch On/off
 102 | ARP | On/off
 103 | ARP | Order
 104 | ARP | Clock division


### PR DESCRIPTION
Docs update to add the arp latch CC number to the MIDI chart