### PR TITLE
Adds Meska preset bank to the site.

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,5 +1,5 @@
 # Redirects from what the browser requests to what we serve
 /webusb              https://plinkysynth.github.io/editor/
-/build               https://www.plinkysynth.com/docs/build-guide-blue
+/build               https://www.plinkysynth.com/docs/build-guide-black
 /fw                  https://www.plinkysynth.com/firmware
 /play                https://www.plinkysynth.com/docs/play-guide

--- a/src/routes/presets.svelte
+++ b/src/routes/presets.svelte
@@ -25,27 +25,51 @@
 
     <Grid>
       <BigArea>
-        <h4>Default bank</h4>
-        <p>This is the default preset set with all 32 patches set to the initial sound.</p>
-        <a class="button" target="_blank" href="/presets/default/PRESETS.uf2">Download</a>
+        <h4>Meska bank</h4>
+        <p>This bank of 32 presets by Meska draws focus to the "dark" side of Plinky, exploring lush delays, cavernous reverb, pitch drift and gnarly saturation.
+        Meska has created a number of great Plinky patch explainers on <a href="https://www.youtube.com/@Meska_Statik" target="_blank">YouTube</a>.</p>
+        
+        <p>Includes the preset file, 8 samples and individual links for the <a href="https://plinkysynth.github.io/editor/">patch editor</a>. 
+        <br>On all patches, Knob A is sensitivity. Set to zero, it turns the sound off.</p>
+        <a class="button" target="_blank" href="/presets/Meska/Meska.zip">Download</a>
       </BigArea>
       <BigArea>
         <h4>LPZW.modules bank</h4>
         <p>These are the presets by LPZW.modules for the Schneidersladen edition of Plinky. It contains the preset file and three samples. For more info, please go to <a href="http://leipzigwest.org/" target="_blank">leipzigwest.org</a>.</p>
         <a class="button" target="_blank" href="/presets/LPZW/LPZW.zip">Download</a>
       </BigArea>
+      <BigArea>
+        <h4>Default bank</h4>
+        <p>This is the default preset set with all 32 patches set to the initial sound.</p>
+        <a class="button" target="_blank" href="/presets/default/PRESETS.uf2">Download</a>
+      </BigArea>
     </Grid>
 
     <h2>Manual preset install instructions</h2>
   
-    <ol>
-      <li>Hold the right encoder down while plugging the USB cable into your Plinky.</li>
-      <li>Plinky will show up as an attached drive and you should see the "tunnel of lights" effect on the LEDs.</li>
-      <li>Drag and drop PRESETS.uf2 to the drive. <b>Make sure that it's called PRESETS.uf2 and nothing else.</b></li>
-      <li>If you're adding samples, drag and drop the SAMPLE1.uf2, SAMPLE2.uf2, etc. that you might have over to the drive as well.</li>
-      <li>While flashing, the LEDs will flicker. This is normal.</li>
-      <li>While you're changing banks, it's a good time to also <a href="/firmware">update your firmware</a> to the latest version! Just download the file and drag and drop while you've got Plinky hooked up.</li>
+    <p>To upload these presets:</p>
+
+    <ul>
+      <li>Unplug all cables from Plinky</li>
+      <li>Connect a USB cable to your Plinky</li>
+      <li>Do not power from Eurorack at the same time, and use only one USB port</li>
+      <li>Hold down the encoder (rightmost knob), and plug the USB cable into your computer</li>
+    </ul>
+
+    <p>Plinky will show up as a drive and you should see the "tunnel of lights" effect on Plinky's LEDs.</p>
+
+    <ul>
+      <li>If you want a backup of your Plinky before replacing the presets, copy the content of the Plinky drive to a folder on your PC.</li>
+      <li>Drag and drop PRESETS.uf2 to the drive. <b>Make sure the file is called PRESETS.uf2 - do not rename.</b></li>
+      <li>Drag and drop SAMPLE0.uf2, SAMPLE1.uf2 .. SAMPLE7.UF2, up to 8 files. You will have to copy them one by one, one after the other.</li>
+    </ul>
+
+    <p>While flashing, the LEDs will flicker. This is normal.</p>
+
+    <ul>
+      <li>While you're changing banks, it's a good time to also <a href="/firmware">update your firmware</a> to the latest version! 
+      Download the file and drag and drop it to the Plinky drive.</li>
       <li>To finish, just click the encoder again. Plinky will boot up and your presets should be present.</li>
-    </ol>
+    </ul>
 
   </div>

--- a/src/server.ts
+++ b/src/server.ts
@@ -87,6 +87,29 @@ app // You can also use Express
 					}));
 				});
 			}
+			else if(req.originalUrl === '/presets/Meska/Meska.zip') {
+							
+				const file = path.join(process.cwd(), 'presets/', 'Meska.zip');
+				const s = fs.createReadStream(file);
+
+				s.on('open', function () {
+
+						res.writeHead(200, {
+							'Content-Type': 'application/octet-stream',
+							'Content-Disposition': 'attachment; filename="Meska.zip"'
+						});
+						s.pipe(res);
+				});
+				
+				s.on('error', function () {
+					res.writeHead(404, {
+						'Content-Type': 'text/plain'
+					});
+					res.end(JSON.stringify({
+						message: `Not found`
+					}));
+				});
+			}
 			else if(req.originalUrl === '/presets/LPZW/LPZW.zip') {
 							
 				const file = path.join(process.cwd(), 'presets/', 'LPZW.zip');


### PR DESCRIPTION
Adds Meska preset bank to the site.

I have also slightly updated the preset instructions, pointing people towards the fact that they 
- need to disconnect all other power sources
- may want to back up their plinky content
- need to drag the samples on one by one

Fix: _redirects - 
https://www.plinkysynth.com/build  now points to the v3 build guide:
https://www.plinkysynth.com/docs/build-guide-black