### PR TITLE
Renamed the Default Bank to Init Sound, Adding Battery Install video

### DIFF
--- a/src/routes/docs/posts/build-guide-plus.md
+++ b/src/routes/docs/posts/build-guide-plus.md
@@ -241,7 +241,7 @@ Before placing the front panel, do a quick first power-up.
 
 Attach a USB-C cable to Plinky+. We recommend using a simple USB phone charger with around 1A power and a USB C to A cable.
 
-Then push the power button. Plinky+ will boot up and show the Plinky logo, then a calibration menu.
+Then push the power button. Plinky+ will boot up and show the calibration menu.
 
 ![Plinky+ DIY Kit – Build Guide](/build-guide-plus/Plinky+_Build-Guide_0096_power.jpg)
 
@@ -407,6 +407,15 @@ Here is a list of Battery Packs we tested with Plinky+.
 </br>Needs adapter: No
 
 </div>
+
+### Battery Installation Video
+
+Nathan / SoundStricker has made an additional video that shows him retrofitting a Battery Pack for Plinky+. Please make sure you carefully read the written instructions below, in addtion to watching the video. Thank you, Nathan, for the video!
+
+<iframe width="800" height="450" src="https://www.youtube.com/embed/QDrn1j6PBww" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+
+Nathan makes fantastic music with Plinky on his channel, it's absolutely worth checking out his [complete Plinky Playlist](https://www.youtube.com/playlist?list=PLS8-DCzLCiFDGTGRJN0lHCSjthzdDtyEc). 
+
 
 ### Installation
 

--- a/src/routes/presets.svelte
+++ b/src/routes/presets.svelte
@@ -52,6 +52,7 @@ https://open.spotify.com/artist/763Sp2pF8qoMUefsjC1MnA?si=WLXMx9eKSGKz67wBAhSFTA
         <iframe width="624" title="" height="351" src="https://www.youtube.com/embed/zXjph5cix2g" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
         <h2>Meska Bank</h2>
+        <p>This bank is the default preset bank on assembled Plinky and Plinky+.</p>
         <p>This bank of 32 presets by Meska draws focus to the "dark" side of Plinky, exploring lush delays, cavernous reverb, pitch drift and gnarly saturation.
         Meska has created a number of great Plinky patch explainers on <a href="https://www.youtube.com/@Meska_Statik" target="_blank">YouTube</a>.</p>
         
@@ -67,8 +68,9 @@ https://open.spotify.com/artist/763Sp2pF8qoMUefsjC1MnA?si=WLXMx9eKSGKz67wBAhSFTA
         <a class="button" target="_blank" href="/presets/LPZW/LPZW.zip">Download</a>
       </BigArea>
       <BigArea>
-        <h2>Default Bank</h2>
-        <p>This is the default preset set with all 32 patches set to the initial sound.</p>
+        <h2>Init Sound</h2>
+        <p>Plinky DIY Kits come without presets installed, encouraging you to explore the sound engine and synth parameters.</p>
+        <p>This is a preset set with all 32 patches set to the initial sound.</p>
         <a class="button" target="_blank" href="/presets/default/PRESETS.uf2">Download</a>
       </BigArea>
     </Grid>


### PR DESCRIPTION
Changing these things:
- Renamed the Default Bank to Init Sound (possibly confusing to users)
- Adding Battery Install video (thank you Nathan / Soundstricker)
- Clarified that after assembly, you see the calibration menu